### PR TITLE
changed typo to properly update item.complete status

### DIFF
--- a/chapters/Session_2.md
+++ b/chapters/Session_2.md
@@ -311,7 +311,7 @@ Now we need to define our `handleStatusChange` method and decide what should hap
 ```js
 methods: {
   handleStatusChange(item) {
-    item.completed = !item.completed;
+    item.complete = !item.complete;
     console.log(item);
   },
 }


### PR DESCRIPTION
Changed `item.completed = !item.completed;` for chapter 2 to `item.complete = !item.complete;` so that status of item:complete properly updates in each todoItem data.